### PR TITLE
Add option for custom renderer

### DIFF
--- a/test/advanced-renderer-test.js
+++ b/test/advanced-renderer-test.js
@@ -1,0 +1,55 @@
+import test from 'tape'
+import MarkdownIt from 'markdown-it'
+import render, { createHighlight } from '../src/index.js'
+
+test('custom renderer with defaults', async (t) => {
+  const OUTPUT = 'Not the droids you are looking for'
+  const file = /* md */`
+---
+title: Hello world
+---
+## Hello, World
+lorem ipsum dolor sit amet
+`.trim()
+
+  const renderer = { render: () => OUTPUT }
+  const { html, tocHtml, title, slug } = await render(file, { renderer })
+
+  t.equal(html, OUTPUT, 'render function is used')
+  t.notOk(tocHtml, 'tocHtml is not generated')
+  t.ok(title && slug, 'frontmatter is parsed and returned')
+
+  t.end()
+})
+
+test('custom markdown-it renderer + highlighter with default config', async (t) => {
+  const CLASS_STRING = 'sjlh'
+  const file = /* md */`
+---
+title: Hello world
+---
+## Hello, World
+
+https://arc.codes
+
+\`\`\`ruby
+def handler
+  puts 'Hello, world'
+end
+\`\`\`
+`.trim()
+
+  const renderer = new MarkdownIt({
+    highlight: await createHighlight({
+      classString: CLASS_STRING,
+    })
+  })
+  const { html, slug, title, tocHtml } = await render(file, { renderer })
+
+  t.ok(html.indexOf('href="https://arc.codes"') === -1, 'linkify is disabled')
+  t.ok(html.indexOf(`<pre class="${CLASS_STRING}"><code data-language="ruby">`) >= 0, 'highlight is enabled with custom options')
+  t.ok(title && slug, 'frontmatter is parsed and returned')
+  t.ok(typeof tocHtml === 'string', 'ToC is a string of HTML')
+
+  t.end()
+})


### PR DESCRIPTION
This would allow a user to pass in a custom renderer as long as it has a `render` method (and optionally, a `use` method for plugins).

So you could create your own instance of `markdown-it`, pass it in to arcdown and all defaults would still be applied.

Or you could even use an entirely different engine that doesn't allow for plugins (the default plugins would be skipped):

```js
import arcdown from 'arcdown'
import snarkdown from 'snarkdown';

const MyCustomRenderer = {
  render: snarkdown,
}

const { html, title, slug } = arcdown(someFile, { renderer: MyCustomRenderer })
// tocHtml isn't available because it's created by a plugin
```

It definitely allows for all kinds of other hackery; which is cool, but if you're using this package, you're probably looking for just some sensible defaults 😄 

A couple examples in test/advanced-renderer-test.js.