### PR TITLE
Add markdown-it-arc-static-img

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@architect/syntaxes": "github:architect/syntaxes#v1.2.1",
     "highlight.js": "^11.5.1",
     "markdown-it": "^13.0.0",
+    "markdown-it-arc-static-img": "^2.0.0",
     "markdown-it-external-anchor": "^1.0.0",
     "markdown-it-toc-and-anchor": "^4.2.0",
     "tiny-frontmatter": "^1.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const TOC_DEFAULTS = {
 import MarkdownIt from 'markdown-it'
 import markdownItTocAndAnchor from 'markdown-it-toc-and-anchor'
 import markdownItExternalAnchor from 'markdown-it-external-anchor'
+import markdownItArcStaticImg from 'markdown-it-arc-static-img'
 import tinyFrontmatter from 'tiny-frontmatter'
 
 import createHighlight from './lib/highlight.js'
@@ -24,6 +25,7 @@ let tocHtml
 const defaultPlugins = {
   markdownItClass,
   markdownItExternalAnchor,
+  markdownItArcStaticImg,
   markdownItTocAndAnchor: [
     // @ts-ignore
     markdownItTocAndAnchor.default,


### PR DESCRIPTION
Adds the `markdown-it-arc-static-img` as a default plugin which seems to be a safe bet to be used frequently.

Signed-off-by: macdonst <simon.macdonald@gmail.com>

