### PR TITLE
detect code fence languages in md doc and refactor highlight

### DIFF
--- a/example/example.html
+++ b/example/example.html
@@ -21,12 +21,14 @@
   <body>
     <main>
       <h1>Example</h1>
-      <p class="prose">lorem ipsum <em>dolor</em> sit <strong>amet</strong><br>
+      <h2 class="title" id="defaults">Defaults</h2>
+<p class="prose">lorem ipsum <em>dolor</em> sit <strong>amet</strong><br>
 https://arc.codes &lt;-- this won’t be linkified because the <code>linkify</code> option was overridden.<br>
-Here’s a link, just in case: <a href="https://arc.codes">Architect</a>. It won’t have <code>target=&quot;_blank&quot;</code> because “markdown-it-external-anchor” is disabled.</p>
+Here’s a link, just in case: <a href="https://arc.codes">Architect</a>. It won’t have <code>target=&quot;_blank&quot;</code> because the “markdown-it-external-anchor” plugin is disabled.</p>
 <p class="prose">Oh, look! “Smart quotes”, because <code>typographer</code> is set to true by default.</p>
-<h2 class="title" id="code-blocks">Code Blocks</h2>
-<h3 id="some-typescript">Some Typescript</h3>
+<h2 class="title" id="%E2%80%9Cfenced%E2%80%9D-code-blocks">“Fenced” Code Blocks</h2>
+<h3 id="a-highlight.js-built-in-language">A highlight.js built-in language</h3>
+<p class="prose">TypeScript is included in in the hljs library and can be automatically registered by <code>arcdown</code>.</p>
 <pre class="hljs mb0 mb1-lg relative"><code data-language="typescript"><span class="hljs-keyword">interface</span> <span class="hljs-title class_">Point</span> {
   <span class="hljs-attr">x</span>: <span class="hljs-built_in">number</span>;
   <span class="hljs-attr">y</span>: <span class="hljs-built_in">number</span>;
@@ -39,7 +41,7 @@ Here’s a link, just in case: <a href="https://arc.codes">Architect</a>. It won
 <span class="hljs-keyword">const</span> point = { <span class="hljs-attr">x</span>: <span class="hljs-number">12</span>, <span class="hljs-attr">y</span>: <span class="hljs-number">26</span> };
 <span class="hljs-title function_">logPoint</span>(point);
 </code></pre>
-<h3 id="custom-syntax">Custom syntax</h3>
+<h3 id="user-provided-custom-syntax">User-provided custom syntax</h3>
 <p class="prose"><a href="https://leanprover.github.io/">Lean</a> is rendered with a provided syntax definition:</p>
 <pre class="hljs mb0 mb1-lg relative"><code data-language="lean"><span class="hljs-keyword">universe</span> u v
 
@@ -59,7 +61,32 @@ Here’s a link, just in case: <a href="https://arc.codes">Architect</a>. It won
 
 #eval h2 <span class="hljs-number">5</span> <span class="hljs-comment">-- 5</span>
 </code></pre>
+<h3 id="another-custom-syntax">Another custom syntax</h3>
+<p class="prose"><a href="https://docs.microsoft.com/en-us/aspnet/core/mvc/views/razor">Razor</a> for ASP.NET Core</p>
+<pre class="hljs mb0 mb1-lg relative"><code data-language="cshtml-razor"><span class="hljs-built_in">@</span>if (value % 2 == 0)
+<span class="hljs-built_in">{</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>The value was even.<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+<span class="hljs-built_in">}</span>
+else if (value &gt;= 1337)
+{
+    <span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>The value is large.<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+<span class="hljs-built_in">}</span>
+else
+<span class="hljs-built_in">{</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>The value is odd and small.<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+<span class="hljs-built_in">}</span>
+</code></pre>
 <h3 id="unknown-languages">Unknown languages</h3>
+<h4 id="built-into-arcdown">Built into <code>arcdown</code></h4>
+<pre class="hljs mb0 mb1-lg relative"><code data-language="arc"><span class="hljs-title">@app</span><span class="hljs-string">
+</span><span class="hljs-string">m</span><span class="hljs-string">y</span><span class="hljs-string">-</span><span class="hljs-string">a</span><span class="hljs-string">p</span><span class="hljs-string">p</span><span class="hljs-string">
+</span><span class="hljs-string">
+</span><span class="hljs-title">@http</span><span class="hljs-string">
+</span><span class="hljs-string">g</span><span class="hljs-string">e</span><span class="hljs-string">t</span><span class="hljs-string"> </span><span class="hljs-string">/</span><span class="hljs-string">f</span><span class="hljs-string">o</span><span class="hljs-string">o</span><span class="hljs-string">
+</span><span class="hljs-string">p</span><span class="hljs-string">o</span><span class="hljs-string">s</span><span class="hljs-string">t</span><span class="hljs-string"> </span><span class="hljs-string">/</span><span class="hljs-string">f</span><span class="hljs-string">o</span><span class="hljs-string">o</span><span class="hljs-string">
+</span><span class="hljs-string"></span></code></pre>
+<h4 id="completely-unknown">Completely unknown</h4>
+<p class="prose">Cobol’s definition isn’t built into hljs and wasn’t added by the user, so this block is printed as-is.</p>
 <pre class="hljs mb0 mb1-lg relative hljs-unregistered"><code data-language="cobol">IDENTIFICATION DIVISION.
 PROGRAM-ID. HELLOWRD.
 
@@ -67,7 +94,6 @@ PROCEDURE DIVISION.
 DISPLAY &quot;HELLO WORLD&quot;.
 STOP RUN.
 </code></pre>
-<p class="prose">Cobol’s definition wasn’t added to this highlight.js instance, so this block is printed as-is.</p>
 <h2 class="title" id="user-provided-plugins">User-provided plugins</h2>
 <h3 id="block-attrs">Block <code>attrs</code></h3>
 <blockquote class="abe" id="Gettysburg">
@@ -82,11 +108,18 @@ STOP RUN.
     <nav>
       <h3>Navigation</h3>
       <ul class="pageToC">
-<li><a href="#code-blocks">Code Blocks</a>
+<li><a href="#defaults">Defaults</a></li>
+<li><a href="#%E2%80%9Cfenced%E2%80%9D-code-blocks">“Fenced” Code Blocks</a>
 <ul>
-<li><a href="#some-typescript">Some Typescript</a></li>
-<li><a href="#custom-syntax">Custom syntax</a></li>
-<li><a href="#unknown-languages">Unknown languages</a></li>
+<li><a href="#a-highlight.js-built-in-language">A highlight.js built-in language</a></li>
+<li><a href="#user-provided-custom-syntax">User-provided custom syntax</a></li>
+<li><a href="#another-custom-syntax">Another custom syntax</a></li>
+<li><a href="#unknown-languages">Unknown languages</a>
+<ul>
+<li><a href="#built-into-arcdown">Built into <code>arcdown</code></a></li>
+<li><a href="#completely-unknown">Completely unknown</a></li>
+</ul>
+</li>
 </ul>
 </li>
 <li><a href="#user-provided-plugins">User-provided plugins</a>

--- a/example/example.md
+++ b/example/example.md
@@ -4,15 +4,19 @@ category: Loremus Categorous
 description: Ipsumi descriptionor.
 ---
 
+## Defaults
+
 lorem ipsum _dolor_ sit **amet**  
 https://arc.codes <-- this won't be linkified because the `linkify` option was overridden.  
-Here's a link, just in case: [Architect](https://arc.codes). It won't have `target="_blank"` because "markdown-it-external-anchor" is disabled.
+Here's a link, just in case: [Architect](https://arc.codes). It won't have `target="_blank"` because the "markdown-it-external-anchor" plugin is disabled.
 
 Oh, look! "Smart quotes", because `typographer` is set to true by default.
 
-## Code Blocks
+## "Fenced" Code Blocks
 
-### Some Typescript
+### A highlight.js built-in language
+
+TypeScript is included in in the hljs library and can be automatically registered by `arcdown`.
 
 ```typescript
 interface Point {
@@ -28,7 +32,7 @@ const point = { x: 12, y: 26 };
 logPoint(point);
 ```
 
-### Custom syntax
+### User-provided custom syntax
 
 [Lean](https://leanprover.github.io/) is rendered with a provided syntax definition:
 
@@ -52,7 +56,41 @@ def h2 (x : Nat) : Nat :=
 #eval h2 5 -- 5
 ```
 
+### Another custom syntax
+
+[Razor](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/razor) for ASP.NET Core
+
+```cshtml-razor
+@if (value % 2 == 0)
+{
+    <p>The value was even.</p>
+}
+else if (value >= 1337)
+{
+    <p>The value is large.</p>
+}
+else
+{
+    <p>The value is odd and small.</p>
+}
+```
+
 ### Unknown languages
+
+#### Built into `arcdown`
+
+```arc
+@app
+my-app
+
+@http
+get /foo
+post /foo
+```
+
+#### Completely unknown
+
+Cobol's definition isn't built into hljs and wasn't added by the user, so this block is printed as-is.
 
 ```cobol
 IDENTIFICATION DIVISION.
@@ -62,8 +100,6 @@ PROCEDURE DIVISION.
 DISPLAY "HELLO WORLD".
 STOP RUN.
 ```
-
-Cobol's definition wasn't added to this highlight.js instance, so this block is printed as-is.
 
 ## User-provided plugins
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,5 +1,6 @@
 import { URL } from 'url'
 import { readFileSync, writeFileSync } from 'fs'
+import razorSyntax from 'highlightjs-cshtml-razor'
 import leanSyntax from 'highlightjs-lean'
 import markdownItAttrs from 'markdown-it-attrs'
 import markdownItEmoji from 'markdown-it-emoji'
@@ -14,8 +15,7 @@ const options = {
     languages: {
       // directly provide the definition function
       lean: leanSyntax,
-      // or the import path for the definition
-      'cshtml-razor': 'highlightjs-cshtml-razor',
+      'cshtml-razor': razorSyntax,
     },
     ignoreIllegals: false,
   },

--- a/example/index.js
+++ b/example/index.js
@@ -1,8 +1,9 @@
 import { URL } from 'url'
 import { readFileSync, writeFileSync } from 'fs'
+import leanSyntax from 'highlightjs-lean'
 import markdownItAttrs from 'markdown-it-attrs'
 import markdownItEmoji from 'markdown-it-emoji'
-import render from '../src/index.js'
+import render from 'arcdown'
 
 // read the sample markdown file
 const file = readFileSync(`${new URL('.', import.meta.url).pathname}/example.md`, 'utf8')
@@ -10,14 +11,12 @@ const file = readFileSync(`${new URL('.', import.meta.url).pathname}/example.md`
 const options = {
   hljs: {
     classString: 'hljs mb0 mb1-lg relative',
-    languages: [
-      // register hljs built-in languages with a string
-      'typescript',
-      // or a custom language as an object
-      { lean: 'highlightjs-lean' },
-      // disable a default language
-      { powershell: false },
-    ],
+    languages: {
+      // directly provide the definition function
+      lean: leanSyntax,
+      // or the import path for the definition
+      'cshtml-razor': 'highlightjs-cshtml-razor',
+    },
     ignoreIllegals: false,
   },
   // set options for Markdown renderer

--- a/example/package.json
+++ b/example/package.json
@@ -4,6 +4,8 @@
     "start": "node index.js"
   },
   "dependencies": {
+    "arcdown": "file:../",
+    "highlightjs-cshtml-razor": "^2.1.1",
     "highlightjs-lean": "^1.1.0",
     "markdown-it-attrs": "^4.1.3",
     "markdown-it-emoji": "^2.0.2"

--- a/readme.md
+++ b/readme.md
@@ -146,22 +146,23 @@ const options = {
 
 ### highlight.js config
 
-A custom `highlight()` method supported by [highlight.js](https://highlightjs.org/) is provided to the `markdown-it`  renderer.  
+A custom `highlight()` method supported by [highlight.js](https://highlightjs.org/) is provided to the `markdown-it`  renderer. `arcdown` will detect languages in the provided Markdown string and attempt to register just those languages in hljs.  
 `ignoreIllegals: true` is the default, but can be set by the user.
-The provided `hljs` instance has 8 registered languages out of the box. A language can be disabled and additional syntaxes can be added in 2 ways:
+
+A language syntax can be added from third party libraries. And, if needed, highlight.js built-in languages can be disabled:
 
 ```javascript
+import leanSyntax from 'highlightjs-lean'
+
 const options = {
   hljs: {
     classString: 'hljs relative mb-2',
-    languages: [
-      // register hljs built-in languages with a string
-      'typescript',
-      // external languages can be added as an object
-      { lean: 'highlightjs-lean' },
-      // disable a default language
-      { powershell: false },
-    ],
+    languages: {
+      // external languages can be added:
+      lean: leanSyntax,
+      // disable a hljs built-in language
+      powershell: false,
+    },
     ignoreIllegals: false,
   },
 }
@@ -203,5 +204,5 @@ We are not married to any single component package or even to the core rendering
 - [x] type defs -- can be expanded
 - [ ] use forked toc plugin from macdonst?
 - [x] benchmarks (try against remark)
-- [ ] look for hljs perf increases
+- [x] look for hljs perf increases
 - [ ] web component enhancements 😏

--- a/src/index.js
+++ b/src/index.js
@@ -48,8 +48,18 @@ export default async function (mdFile, rendererOptions = {}) {
     renderer: customRenderer = null, // override renderer
   } = rendererOptions
 
+  const { attributes, body } = tinyFrontmatter(mdFile)
+
+  const foundLangs = new Set()
+  const fenceR = /`{3}(?:(.*$))?[\s\S]*?`{3}/gm
+  let match
+  do {
+    match = fenceR.exec(body)
+    if (match) foundLangs.add(match[1])
+  } while (match)
+
   const renderer = customRenderer || new MarkdownIt({
-    highlight: await createHighlight(hljs),
+    highlight: await createHighlight(hljs, foundLangs),
     ...MARKDOWN_DEFAULTS,
     ...markdownIt,
   })
@@ -78,7 +88,6 @@ export default async function (mdFile, rendererOptions = {}) {
     }
   }
 
-  const { attributes, body } = tinyFrontmatter(mdFile)
   const html = renderer.render(body)
   const title = attributes.title || null
 

--- a/test/advanced-renderer-test.js
+++ b/test/advanced-renderer-test.js
@@ -32,6 +32,12 @@ title: Hello world
 
 https://arc.codes
 
+\`\`\`javascript
+async function () {
+  console.log('Hello, world')
+}
+\`\`\`
+
 \`\`\`ruby
 def handler
   puts 'Hello, world'
@@ -40,14 +46,16 @@ end
 `.trim()
 
   const renderer = new MarkdownIt({
-    highlight: await createHighlight({
-      classString: CLASS_STRING,
-    })
+    highlight: await createHighlight(
+      { classString: CLASS_STRING },
+      [ 'ruby' ]
+    ),
   })
   const { html, slug, title, tocHtml } = await render(file, { renderer })
 
   t.ok(html.indexOf('href="https://arc.codes"') === -1, 'linkify is disabled')
-  t.ok(html.indexOf(`<pre class="${CLASS_STRING}"><code data-language="ruby">`) >= 0, 'highlight is enabled with custom options')
+  t.ok(html.indexOf(`<pre class="${CLASS_STRING}"><code data-language="ruby">`) >= 0, 'highlight is enabled for provided languages')
+  t.ok(html.indexOf(`<pre class="${CLASS_STRING} hljs-unregistered"><code data-language="javascript">`) >= 0, 'not provided languages are not highlighted')
   t.ok(title && slug, 'frontmatter is parsed and returned')
   t.ok(typeof tocHtml === 'string', 'ToC is a string of HTML')
 

--- a/test/renderer-hljs-test.js
+++ b/test/renderer-hljs-test.js
@@ -1,0 +1,49 @@
+import test from 'tape'
+import render from '../src/index.js'
+
+test('renderer hljs options', async (t) => {
+  const HLJS_CLASS = 'hljs'
+  const file = /* md */`
+## Code things
+
+\`\`\`arc
+# Architect isn't in hljs but it is in arcdown
+\`\`\`
+
+\`\`\`javascript
+// JavaScript things just work
+\`\`\`
+
+\`\`\`html
+<!-- HTML things are XML things -->
+\`\`\`
+
+\`\`\`perl
+# perl is built into hljs but should be unregistered
+\`\`\`
+
+\`\`\`cobol
+* COBOL things aren't in hljs or arcdown or provided by the user
+\`\`\`
+`.trim()
+  const options = {
+    hljs: {
+      classString: HLJS_CLASS,
+      languages: [
+        { perl: false },
+        // TODO: test a custom syntax
+      ],
+    },
+  }
+
+  const { html } = await render(file, options)
+
+  t.ok(html.indexOf(`<pre class="${HLJS_CLASS}`) >= 0, 'highlight.js is working')
+  t.ok(html.indexOf('<pre class="hljs"><code data-language="arc">') >= 0, 'arc syntax is added and registered')
+  t.ok(html.indexOf('<pre class="hljs"><code data-language="javascript">') >= 0, 'js syntax is hljs-builtin')
+  t.ok(html.indexOf('<pre class="hljs"><code data-language="html">') >= 0, 'html is registered via xml')
+  t.ok(html.indexOf('<pre class="hljs hljs-unregistered"><code data-language="perl">') >= 0, 'hljs-builtin syntax unregistered')
+  t.ok(html.indexOf('<pre class="hljs hljs-unregistered"><code data-language="cobol">') >= 0, 'unsupported hljs lang is still rendered without error')
+
+  t.end()
+})

--- a/test/renderer-hljs-test.js
+++ b/test/renderer-hljs-test.js
@@ -29,10 +29,8 @@ test('renderer hljs options', async (t) => {
   const options = {
     hljs: {
       classString: HLJS_CLASS,
-      languages: [
-        { perl: false },
-        // TODO: test a custom syntax
-      ],
+      languages: { perl: false },
+      // TODO: test a custom syntax
     },
   }
 

--- a/test/renderer-test.js
+++ b/test/renderer-test.js
@@ -118,60 +118,6 @@ test('renderer plugin overrides', async (t) => {
   t.end()
 })
 
-test('renderer hljs options', async (t) => {
-  const HLJS_CLASS = 'hljs'
-  const file = /* md */`
-## Code things
-
-\`\`\`arc
-@app
-hello-world
-\`\`\`
-
-\`\`\`javascript
-// JavaScript
-\`\`\`
-
-\`\`\`html
-<!-- HTML things -->
-\`\`\`
-
-\`\`\`typescript
-// TypeScript
-\`\`\`
-
-\`\`\`perl
-# perl things
-\`\`\`
-
-\`\`\`python
-# python things
-\`\`\`
-`.trim()
-  const options = {
-    hljs: {
-      classString: HLJS_CLASS,
-      languages: [
-        'typescript',
-        { python: false },
-        // TODO: test a custom syntax
-      ],
-    },
-  }
-
-  const { html } = await render(file, options)
-
-  t.ok(html.indexOf(`<pre class="${HLJS_CLASS}`) >= 0, 'highlight.js is working')
-  t.ok(html.indexOf('<pre class="hljs"><code data-language="javascript">') >= 0, 'js syntax is registered by default')
-  t.ok(html.indexOf('<pre class="hljs"><code data-language="html">') >= 0, 'html is registered via xml')
-  t.ok(html.indexOf('<pre class="hljs"><code data-language="arc">') >= 0, 'arc syntax is added and registered')
-  t.ok(html.indexOf('<pre class="hljs hljs-unregistered"><code data-language="perl">') >= 0, 'hljjs-builtin syntax unregistered')
-  t.ok(html.indexOf('<pre class="hljs"><code data-language="typescript">') >= 0, 'hljs-builtin added syntax is registered')
-  t.ok(html.indexOf('<pre class="hljs hljs-unregistered"><code data-language="python">') >= 0, 'default syntax can be un-registered')
-
-  t.end()
-})
-
 test('renderer custom slug', async (t) => {
   const TITLE = 'Test Doc'
   const CUSTOM_SLUG = 'custom-slug'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,9 +2,9 @@
 
 // TODO: types for each default plugin config
 export interface DefaultPlugins {
-  markdownItClass?: object | false;
-  markdownItExternalAnchor?: object | false;
-  markdownItTocAndAnchor?: object | false;
+  markdownItClass?: object | boolean;
+  markdownItExternalAnchor?: object | boolean;
+  markdownItTocAndAnchor?: object | boolean;
 }
 
 export interface RendererOptions {
@@ -12,11 +12,20 @@ export interface RendererOptions {
   hljs?: object;
   pluginOverrides?: DefaultPlugins;
   plugins?: object;
+  renderer?: {
+    render: (markdown: string) => string,
+    use?: any,
+  };
 }
 
 export const defaultPlugins: DefaultPlugins;
 
 export function slugify(s: string): string;
+
+export function createHighlight(
+  options: object,
+  foundLanguages: string[] | null
+): Promise<(code: any, language: any) => string>;
 
 export interface RenderResult {
   html: string;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -3,6 +3,7 @@
 
 import { readFileSync } from 'fs';
 import render, {
+  createHighlight,
   defaultPlugins,
   slugify,
   DefaultPlugins,
@@ -26,11 +27,10 @@ async function test() {
   const options: RendererOptions = {
     hljs: {
       classString: 'hljs mb0 mb1-lg relative',
-      languages: [
-        'typescript',
-        { lean: 'highlightjs-lean' },
-        { powershell: false },
-      ],
+      languages: {
+        lean: 'highlightjs-lean',
+        powershell: false,
+      },
       ignoreIllegals: false,
     },
     markdownIt: { linkify: false },
@@ -57,6 +57,21 @@ async function test() {
   const { html, tocHtml, slug, title, foo } = extendedResult;
 
   foo?.bar;
+
+  const highlight = await createHighlight(
+    {
+      classString: 'sjlh',
+      languages: {
+        lean: 'highlightjs-lean',
+        powershell: false,
+      },
+    },
+    ['ruby', 'lean']
+  );
+  const customRendererOptions = {
+    renderer: new MarkdownIt({ highlight }),
+  };
+  const customRendererResult: RenderResult = await render(file, customRendererOptions);
 }
 
 test();


### PR DESCRIPTION
Instead of default language definitions for hljs, this will detect what is needed to render the Markdown body and load just those syntax definitions.

Still one failing test to allow a user to disable specific languages even if they are found in the Markdown body.