### PR TITLE
move frontmatter and strip strings of leading/trailing quotes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,15 @@ lorem ipsum _dolor_ sit **amet**
 [Architect](https://arc.codes/)
 `
 
-const { html, tocHtml, slug, title, category } = await render(doc)
+const {
+  frontmatter  // attributes from frontmatter
+  html,        // the good stuff: HTML!
+  slug,        // a URL-friendly slug
+  title,       // document title from the frontmatter
+  tocHtml,     // an HTML table of contents
+} = await render(doc)
+
+
 ```
 
 See ./example/ for a kitchen sink demo.
@@ -57,24 +65,24 @@ See ./example/ for a kitchen sink demo.
 - `title` the document title, lifted from the document's frontmatter. possibly empty
 - `slug` a slug of the title. possibly empty
   - created in the same way as links in the table of contents.
-- `...` all remaining frontmatter. possibly empty
+- `frontmatter` all remaining frontmatter. possibly empty
   - passed straight from the [`tiny-frontmatter` parser](https://github.com/rjreed/tiny-frontmatter)
 
 ```javascript
 import render from 'arcdown'
 
 const {
-  html,     // the good stuff: HTML!
-  tocHtml,  // an HTML table of contents
-  slug,     // a URL-friendly slug
-  title,    // document title from the frontmatter
-  // ...       any other attributes from frontmatter
+  frontmatter  // attributes from frontmatter
+  html,        // the good stuff: HTML!
+  slug,        // a URL-friendly slug
+  title,       // document title from the frontmatter
+  tocHtml,     // an HTML table of contents
 } = await render(file, options)
 ```
 
 ## Configuration
 
-`arcdown` is set up to be used without any configuration. Out-of-the-box it uses defaults and conventions preferred by the Architect team.
+`arcdown` is set up to be used without any configuration. Out-of-the-box it uses defaults and conventions preferred by the Architect team (Architect project not required).
 
 However, the renderer is customizable and extensible.
 

--- a/readme.md
+++ b/readme.md
@@ -43,14 +43,12 @@ lorem ipsum _dolor_ sit **amet**
 `
 
 const {
-  frontmatter  // attributes from frontmatter
+  frontmatter, // attributes from frontmatter
   html,        // the good stuff: HTML!
   slug,        // a URL-friendly slug
   title,       // document title from the frontmatter
   tocHtml,     // an HTML table of contents
 } = await render(doc)
-
-
 ```
 
 See ./example/ for a kitchen sink demo.
@@ -72,7 +70,7 @@ See ./example/ for a kitchen sink demo.
 import render from 'arcdown'
 
 const {
-  frontmatter  // attributes from frontmatter
+  frontmatter, // attributes from frontmatter
   html,        // the good stuff: HTML!
   slug,        // a URL-friendly slug
   title,       // document title from the frontmatter

--- a/src/index.js
+++ b/src/index.js
@@ -89,6 +89,14 @@ export default async function (mdFile, rendererOptions = {}) {
   }
 
   const html = renderer.render(body)
+
+  if (attributes) {
+    for (const attr in attributes) {
+      const value = attributes[attr]
+      attributes[attr] = value.replace(/^"|"$|^'|'$/g, '')
+    }
+  }
+
   let { slug, title } = attributes
   if (!slug) slug = title ? slugify(title) : null
 

--- a/src/index.js
+++ b/src/index.js
@@ -89,14 +89,15 @@ export default async function (mdFile, rendererOptions = {}) {
   }
 
   const html = renderer.render(body)
-  const title = attributes.title || null
+  let { slug, title } = attributes
+  if (!slug) slug = title ? slugify(title) : null
 
   return {
-    slug: title ? slugify(title) : null,
-    ...attributes,
     title,
     html,
     tocHtml,
+    slug,
+    frontmatter: attributes,
   }
 }
 

--- a/test/renderer-plugins-test.js
+++ b/test/renderer-plugins-test.js
@@ -1,0 +1,34 @@
+import test from 'tape'
+import render from '../src/index.js'
+
+test('renderer plugin overrides', async (t) => {
+  const TOC_CLASS = 'pageToC'
+  const file = /* md */`
+## Deploy to AWS
+
+[AWS](https://aws.amazon.com/) is a cloud computing platform that makes it easy to build, deploy, and manage applications and services.
+`.trim()
+
+  const options = {
+    pluginOverrides: {
+      markdownItTocAndAnchor: { tocClassName: TOC_CLASS },
+      markdownItClass: {
+        h2: [ 'title' ],
+        p: [ 'prose' ],
+      },
+      markdownItExternalAnchor: false,
+    },
+  }
+
+  const {
+    html,
+    tocHtml,
+  } = await render(file, options)
+
+  t.ok(tocHtml.indexOf(`class="${TOC_CLASS}`) >= 0, 'ToC class is present')
+  t.ok(html.indexOf('target="_blank">AWS</a>') < 0, 'External link targets = blank')
+  t.ok(html.indexOf('<h2 class="title"') >= 0, 'h2.title')
+  t.ok(html.indexOf('<p class="prose"') >= 0, 'p.prose')
+
+  t.end()
+})

--- a/test/renderer-test.js
+++ b/test/renderer-test.js
@@ -1,57 +1,6 @@
 import test from 'tape'
 import render from '../src/index.js'
 
-test('renderer baseline with frontmatter', async (t) => {
-  const TITLE = 'Test Doc'
-  const TITLE_SLUG = 'test-doc'
-  const CATEGORY = 'Testing'
-  const DESCRIPTION = 'Make sure we get Markdown'
-  const LINK = 'https://arc.codes'
-  const file = /* md */`
----
-title: ${TITLE}
-category: ${CATEGORY}
-description: ${DESCRIPTION}
----
-
-> Architect is a simple tool to build and deliver powerful functional web apps and APIs
-
-Visit ${LINK} for more info.
-
-## Deploy to AWS
-
-[AWS](https://aws.amazon.com/) is a cloud computing platform that makes it easy to build, deploy, and manage applications and services.
-
-### $ubsection 2.1?
-
-## Section 3
-
-lorem ipsum dolor sit amet
-`.trim()
-
-  const {
-    category,
-    description,
-    html,
-    tocHtml,
-    slug,
-    title,
-  } = await render(file)
-
-  t.equal(title, TITLE, 'title attribute is present')
-  t.equal(category, CATEGORY, 'category attribute is present')
-  t.equal(description, DESCRIPTION, 'description attribute is present')
-  t.equal(slug, TITLE_SLUG, 'slug attribute is generated')
-  t.ok(typeof tocHtml === 'string', 'ToC is a string of HTML')
-  t.ok(typeof html === 'string', 'html is a string of HTML')
-  t.ok(html.indexOf('id="deploy-to-aws"') >= 0, 'Headings are linkified')
-  t.ok(html.indexOf('id="%24ubsection-2.1%3F"') >= 0, 'Complex headings are linkified')
-  t.ok(html.indexOf(`>${LINK}</a`) >= 0, 'link linkified')
-  t.ok(html.indexOf('target="_blank">AWS</a>') >= 0, 'External link targets = blank')
-
-  t.end()
-})
-
 test('renderer without frontmatter', async (t) => {
   const file = /* md */`
 ## Hello, World
@@ -86,34 +35,87 @@ Visit ${LINK} for more info.
   t.end()
 })
 
-test('renderer plugin overrides', async (t) => {
-  const TOC_CLASS = 'pageToC'
+test('renderer baseline with frontmatter', async (t) => {
+  const TITLE = 'Test Doc'
+  const TITLE_SLUG = 'test-doc'
+  const CATEGORY = 'Testing'
+  const DESCRIPTION = 'Make sure we get Markdown'
+  const LINK = 'https://arc.codes'
   const file = /* md */`
+---
+title: ${TITLE}
+category: ${CATEGORY}
+description: ${DESCRIPTION}
+---
+
+> Architect is a simple tool to build and deliver powerful functional web apps and APIs
+
+Visit ${LINK} for more info.
+
 ## Deploy to AWS
 
 [AWS](https://aws.amazon.com/) is a cloud computing platform that makes it easy to build, deploy, and manage applications and services.
+
+### $ubsection 2.1?
+
+## Section 3
+
+lorem ipsum dolor sit amet
 `.trim()
 
-  const options = {
-    pluginOverrides: {
-      markdownItTocAndAnchor: { tocClassName: TOC_CLASS },
-      markdownItClass: {
-        h2: [ 'title' ],
-        p: [ 'prose' ],
-      },
-      markdownItExternalAnchor: false,
-    },
-  }
-
   const {
+    frontmatter,
     html,
     tocHtml,
-  } = await render(file, options)
+    slug,
+    title,
+  } = await render(file)
 
-  t.ok(tocHtml.indexOf(`class="${TOC_CLASS}`) >= 0, 'ToC class is present')
-  t.ok(html.indexOf('target="_blank">AWS</a>') < 0, 'External link targets = blank')
-  t.ok(html.indexOf('<h2 class="title"') >= 0, 'h2.title')
-  t.ok(html.indexOf('<p class="prose"') >= 0, 'p.prose')
+  t.equal(title, TITLE, 'title attribute is present')
+  t.equal(typeof frontmatter, 'object', 'frontmatter is an object')
+  t.equal(frontmatter.title, TITLE, 'title attribute is present')
+  t.equal(frontmatter.category, CATEGORY, 'category attribute is present')
+  t.equal(frontmatter.description, DESCRIPTION, 'description attribute is present')
+  t.equal(slug, TITLE_SLUG, 'slug attribute is generated')
+  t.ok(typeof tocHtml === 'string', 'ToC is a string of HTML')
+  t.ok(typeof html === 'string', 'html is a string of HTML')
+  t.ok(html.indexOf('id="deploy-to-aws"') >= 0, 'Headings are linkified')
+  t.ok(html.indexOf('id="%24ubsection-2.1%3F"') >= 0, 'Complex headings are linkified')
+  t.ok(html.indexOf(`>${LINK}</a`) >= 0, 'link linkified')
+  t.ok(html.indexOf('target="_blank">AWS</a>') >= 0, 'External link targets = blank')
+
+  t.end()
+})
+
+test('weird strings in frontmatter', async (t) => {
+  const file = /* md */`
+---
+title: "Using GitHub Actions with Architect"
+image: 'post-assets/gh-actions.png'
+category: book-club
+description: "GitHub Actions is a continuous integration and continuous delivery (CI/CD) platform that allows you to automate your build, test, and deployment pipeline. We’ve recently created some composite actions to test every pull request to your repository and deploy tagged releases to production."
+author: 'Simon MacDonald'
+avatar: 'simon.png'
+published: 'April 22, 2022'
+---
+
+## Mmmm... YAML...
+
+`.trim()
+  const expected = {
+    title: 'Using GitHub Actions with Architect',
+    image: 'post-assets/gh-actions.png',
+    category: 'book-club',
+    description: 'GitHub Actions is a continuous integration and continuous delivery (CI/CD) platform that allows you to automate your build, test, and deployment pipeline. We’ve recently created some composite actions to test every pull request to your repository and deploy tagged releases to production.',
+    author: 'Simon MacDonald',
+    avatar: 'simon.png',
+    published: 'April 22, 2022',
+  }
+
+  const { frontmatter, slug } = await render(file)
+
+  t.deepEqual(frontmatter, expected, 'frontmatter is parsed correctly')
+  t.equal(slug, 'using-github-actions-with-architect', 'slug is generated correctly')
 
   t.end()
 })
@@ -130,10 +132,11 @@ slug: ${CUSTOM_SLUG}
 lorem ipsum dolor sit amet
 `.trim()
 
-  const { title, slug } = await render(file)
+  const { frontmatter, slug, title } = await render(file)
 
   t.equal(title, TITLE, 'title attribute is present')
   t.equal(slug, CUSTOM_SLUG, 'slug is customized')
+  t.equal(frontmatter.slug, CUSTOM_SLUG, 'slug is also on frontmatter')
 
   t.end()
 })

--- a/test/renderer-test.js
+++ b/test/renderer-test.js
@@ -92,10 +92,10 @@ test('weird strings in frontmatter', async (t) => {
 ---
 title: "Using GitHub Actions with Architect"
 image: 'post-assets/gh-actions.png'
-category: book-club
-description: "GitHub Actions is a continuous integration and continuous delivery (CI/CD) platform that allows you to automate your build, test, and deployment pipeline. We’ve recently created some composite actions to test every pull request to your repository and deploy tagged releases to production."
+category: ci-cd
+description: "GitHub Actions is a "continuous integration" and continuous delivery (CI/CD) platform."
 author: 'Simon MacDonald'
-avatar: 'simon.png'
+avatar: simon.png
 published: 'April 22, 2022'
 ---
 
@@ -105,8 +105,8 @@ published: 'April 22, 2022'
   const expected = {
     title: 'Using GitHub Actions with Architect',
     image: 'post-assets/gh-actions.png',
-    category: 'book-club',
-    description: 'GitHub Actions is a continuous integration and continuous delivery (CI/CD) platform that allows you to automate your build, test, and deployment pipeline. We’ve recently created some composite actions to test every pull request to your repository and deploy tagged releases to production.',
+    category: 'ci-cd',
+    description: 'GitHub Actions is a "continuous integration" and continuous delivery (CI/CD) platform.',
     author: 'Simon MacDonald',
     avatar: 'simon.png',
     published: 'April 22, 2022',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,10 +32,7 @@ export interface RenderResult {
   tocHtml: string;
   title?: string;
   slug?: string;
-}
-
-export interface RenderResult {
-  [prop: string]: any;
+  frontmatter?: Record<string, any>;
 }
 
 export default function render(

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -54,9 +54,9 @@ async function test() {
   const file = readFileSync('./test.md', 'utf8');
 
   const extendedResult: RenderResult = await render(file, options);
-  const { html, tocHtml, slug, title, foo } = extendedResult;
+  const { html, tocHtml, slug, title, frontmatter } = extendedResult;
 
-  foo?.bar;
+  frontmatter?.foo === 'bar';
 
   const highlight = await createHighlight(
     {


### PR DESCRIPTION
```js
const {
  frontmatter  // attributes from frontmatter
  html,        // the good stuff: HTML!
  slug,        // a URL-friendly slug
  title,       // document title from the frontmatter
  tocHtml,     // an HTML table of contents
} = await render(doc)
```

`title` and `slug` are still available at the top level but can be `null`

a test now exists to handle weird YAML strings in `test/renderer-test.js`