### PR TITLE
Issue #8: arcdown dies if code language is not specified

### DIFF
--- a/src/lib/highlight.js
+++ b/src/lib/highlight.js
@@ -38,7 +38,7 @@ export default async function (
         console.info(`Unable to import "${languageName}" from hljs`)
       }
     }
-    else if (langDef.constructor.name === 'Object') {
+    else if (langDef?.constructor.name === 'Object') {
       languageName = Object.keys(langDef)[0]
 
       if (typeof langDef[languageName] === 'string') {

--- a/test/renderer-hljs-test.js
+++ b/test/renderer-hljs-test.js
@@ -22,6 +22,10 @@ test('renderer hljs options', async (t) => {
 # perl is built into hljs but should be unregistered
 \`\`\`
 
+\`\`\`
+plain text
+\`\`\`
+
 \`\`\`cobol
 * COBOL things aren't in hljs or arcdown or provided by the user
 \`\`\`
@@ -35,12 +39,14 @@ test('renderer hljs options', async (t) => {
   }
 
   const { html } = await render(file, options)
+  console.log(html)
 
   t.ok(html.indexOf(`<pre class="${HLJS_CLASS}`) >= 0, 'highlight.js is working')
   t.ok(html.indexOf('<pre class="hljs"><code data-language="arc">') >= 0, 'arc syntax is added and registered')
   t.ok(html.indexOf('<pre class="hljs"><code data-language="javascript">') >= 0, 'js syntax is hljs-builtin')
   t.ok(html.indexOf('<pre class="hljs"><code data-language="html">') >= 0, 'html is registered via xml')
   t.ok(html.indexOf('<pre class="hljs hljs-unregistered"><code data-language="perl">') >= 0, 'hljs-builtin syntax unregistered')
+  t.ok(html.indexOf('<pre class="hljs hljs-unregistered"><code data-language="">') >= 0, 'hljs-builtin syntax unregistered but no language specified')
   t.ok(html.indexOf('<pre class="hljs hljs-unregistered"><code data-language="cobol">') >= 0, 'unsupported hljs lang is still rendered without error')
 
   t.end()


### PR DESCRIPTION
This `?` prevents arcdown from throwing an exception. I do love one character fixes.